### PR TITLE
家計簿ヘッダの日表示の修正

### DIFF
--- a/app/src/main/res/layout/household_account_book_header.xml
+++ b/app/src/main/res/layout/household_account_book_header.xml
@@ -27,7 +27,7 @@
         android:layout_width="0dp"
         android:layout_height="0dp"
         android:orientation="vertical"
-        app:layout_constraintGuide_percent="0.15" />
+        app:layout_constraintGuide_percent="0.17" />
 
     <TextView
         android:id="@+id/dayOfWeekTextView"


### PR DESCRIPTION
OPPO Reno Aにて家計簿リスト表示の日が改行されて表示される件を修正する。