### PR TITLE
バージョンアップ

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -94,7 +94,7 @@ dependencies {
     implementation("org.jetbrains.kotlinx:kotlinx-coroutines-android:1.5.2-native-mt")
 
     // AndroidX
-    implementation("androidx.core:core-ktx:1.6.0")
+    implementation("androidx.core:core-ktx:1.7.0")
     implementation("androidx.appcompat:appcompat:1.3.1")
     implementation("androidx.constraintlayout:constraintlayout:2.1.1")
     implementation("androidx.fragment:fragment-ktx:1.4.0-alpha08")
@@ -103,8 +103,8 @@ dependencies {
     implementation("androidx.preference:preference:1.1.1")
 
     // AndroidX Lifecycle
-    implementation("androidx.lifecycle:lifecycle-livedata-ktx:2.3.1")
-    implementation("androidx.lifecycle:lifecycle-viewmodel-ktx:2.3.1")
+    implementation("androidx.lifecycle:lifecycle-livedata-ktx:2.4.0")
+    implementation("androidx.lifecycle:lifecycle-viewmodel-ktx:2.4.0")
 
     // AndroidX Room
     implementation("androidx.room:room-runtime:2.3.0")
@@ -114,10 +114,10 @@ dependencies {
     implementation("com.google.android.material:material:1.4.0")
 
     // Flipper
-    debugImplementation("com.facebook.flipper:flipper:0.115.0")
-    debugImplementation("com.facebook.soloader:soloader:0.10.1")
-    debugImplementation("com.facebook.flipper:flipper-leakcanary2-plugin:0.115.0")
-    releaseImplementation("com.facebook.flipper:flipper-noop:0.115.0")
+    debugImplementation("com.facebook.flipper:flipper:0.118.1")
+    debugImplementation("com.facebook.soloader:soloader:0.10.3")
+    debugImplementation("com.facebook.flipper:flipper-leakcanary2-plugin:0.118.1")
+    releaseImplementation("com.facebook.flipper:flipper-noop:0.118.1")
 
     implementation("com.orhanobut:logger:2.2.0")
     debugImplementation("com.squareup.leakcanary:leakcanary-android:2.7")


### PR DESCRIPTION
- core 1.6.0 -> 1.7.0
- lifecycle 2.3.1 -> 2.4.0
- flipper 0.115.0 -> 0.118.1
- soloader 0.10.1 -> 0.10.3